### PR TITLE
block invalid file names for scripts

### DIFF
--- a/src/main/java/io/github/codeutilities/screen/script/ScriptCreationScreen.java
+++ b/src/main/java/io/github/codeutilities/screen/script/ScriptCreationScreen.java
@@ -5,16 +5,36 @@ import io.github.codeutilities.screen.CScreen;
 import io.github.codeutilities.screen.widget.CButton;
 import io.github.codeutilities.screen.widget.CTextField;
 import io.github.codeutilities.script.ScriptManager;
+import net.minecraft.sound.SoundEvent;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ScriptCreationScreen extends CScreen {
+
+    // invalid file name chars
+    // there's definitely a better place to put this but this felt the simplest rn
+    Pattern ILLEGAL_CHARS = Pattern.compile("[\\\\/:*?\"<>|]");
 
     protected ScriptCreationScreen() {
         super(100, 60);
 
         CTextField name = new CTextField("My Script", 2, 2, 96, 36, true);
+
+        name.setChangedListener(() -> name.textColor = 0xFFFFFF);
+
         widgets.add(name);
 
         widgets.add(new CButton(2, 42, 48, 15, "Create", () -> {
+            String scriptName = name.getText();
+
+            Matcher m = ILLEGAL_CHARS.matcher(scriptName);
+
+            if (m.find()) {
+                name.textColor = 0xFF3333;
+                return;
+            }
+
             ScriptManager.getInstance().createScript(name.getText());
             CodeUtilities.MC.setScreen(new ScriptListScreen());
         }));

--- a/src/main/java/io/github/codeutilities/script/ScriptManager.java
+++ b/src/main/java/io/github/codeutilities/script/ScriptManager.java
@@ -22,6 +22,7 @@ import io.github.codeutilities.script.event.ScriptEvent;
 import io.github.codeutilities.script.event.ScriptStartUpEvent;
 import io.github.codeutilities.util.FileUtil;
 import java.io.File;
+import java.nio.file.InvalidPathException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -138,7 +139,15 @@ public class ScriptManager implements Loadable {
     public void createScript(String name) {
         Script script = new Script(name, new ArrayList<>(),false);
         scripts.add(script);
-        File file = FileUtil.cuFolder("Scripts").resolve(name + ".json").toFile();
+
+        File file = null;
+        try {
+            file = FileUtil.cuFolder("Scripts").resolve(name + ".json").toFile();
+        } catch (InvalidPathException e) {
+            LOGGER.error("Failed to save script: " + script.getFile().getName());
+            e.printStackTrace();
+        }
+
         script.setFile(file);
         saveScript(script);
     }


### PR DESCRIPTION
add a regex to keep ppl from crashing the game with script names (turns text red for bad name)

also added an extra try/catch so even if they're on some strange extra restrictive file system it'll hopefully still catch