### PR TITLE
Make /codeutilities not require creative

### DIFF
--- a/src/main/java/io/github/codeutilities/commands/misc/CodeUtilitiesCommand.java
+++ b/src/main/java/io/github/codeutilities/commands/misc/CodeUtilitiesCommand.java
@@ -15,12 +15,8 @@ public class CodeUtilitiesCommand implements Command {
     public void register(CommandDispatcher<FabricClientCommandSource> cd) {
         cd.register(literal("codeutilities")
                 .executes(ctx -> {
-                    if (CodeUtilities.MC.player.isCreative()) {
-                        CodeUtilitiesScreen gui = new CodeUtilitiesScreen();
-                        CodeUtilities.MC.send(() -> CodeUtilities.MC.setScreen(gui));
-                    } else {
-                        ChatUtil.sendMessage(new TranslatableText("command.codeutilities.require_dev_mode", ChatType.FAIL));
-                    }
+                    CodeUtilitiesScreen gui = new CodeUtilitiesScreen();
+                    CodeUtilities.MC.send(() -> CodeUtilities.MC.setScreen(gui));
                     return 1;
                 })
         );


### PR DESCRIPTION
not sure why I didn't change this when I first ported it lol
currently no reason for this command to require dev or build, just deleted the check

tested, works in both creative and survival